### PR TITLE
docs: fix Mermaid diagram in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,19 @@ pnpm run sync-notion
 - **アイコン**: Astro Icon
 - **デプロイ**: Cloudflare Workers
 
+## 構成図
+
+```mermaid
+graph TD
+  Notion[Notion Database] --> SyncScript[Node.js Sync Script]
+  SyncScript --> Markdown[Markdown + Frontmatter]
+  Markdown --> Astro[Astro SSG]
+  Astro --> Assets[ /public, /content ]
+  Astro --> GitHubActions[GitHub Actions]
+  GitHubActions --> Cloudflare[Cloudflare Pages]
+  Cloudflare --> User[User Access via CDN]
+```
+
 ## ライセンス
 
 このプロジェクトは [Astro Theme Cody](https://github.com/kirontoo/astro-theme-cody) をベースにしています。


### PR DESCRIPTION
Replace Assets[/text/] shape that conflicted with slashes in label.\nUse rectangle: Assets[ /public, /content ].