### PR TITLE
chore: remove dependency on per-post description

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,13 +59,14 @@ pnpm run sync-notion
 - `NOTION_DATABASE_ID`: 同期対象のNotionデータベースID
 
 #### Notionデータベースの要件
-記事として認識されるには、以下のプロパティが必要です：
-- **Status** (Status): "Published"に設定された記事のみ同期
+記事として認識されるための主なプロパティ：
+- **Status** (Status): "Published" に設定された記事のみ同期
 - **Title/Name** (Title): 記事タイトル
-- **Description** (Text): 記事の説明（オプション）
-- **PublishDate/Date** (Date): 公開日（オプション）
-- **Tags** (Multi-select): タグ（オプション）
-- **Series** (Select): シリーズ名（オプション）
+- **PublishDate/Date** (Date): 公開日（任意）
+- **Tags** (Multi-select): タグ（任意）
+- **Series** (Select): シリーズ名（任意）
+
+備考: 記事の説明プロパティは不要です。説明が未設定でもビルド・表示に影響はありません。
 
 ## 技術構成
 

--- a/src/layouts/BlogPost.astro
+++ b/src/layouts/BlogPost.astro
@@ -143,9 +143,9 @@ const articleDate = updatedDate?.toISOString() ?? pubDate.toISOString();
 			}
 			<SocialMediaLinks />
 			<span class="!my-4 text-accent" aria-hidden>---</span>
-			<p>
-				{description}
-			</p>
+			{description && (
+				<p>{description}</p>
+			)}
 			{
 				series && (
 					<div class="pt-2 hidden md:block">

--- a/src/layouts/GenericPost.astro
+++ b/src/layouts/GenericPost.astro
@@ -18,9 +18,9 @@ const { frontmatter: {title, description}, headings } = Astro.props
 			{siteConfig.profile.description && (<p>{siteConfig.profile.description}</p>)}
 			<SocialMediaLinks/>
 			<span class="!my-4 text-accent" aria-hidden>---</span>
-			<p>
-				{description}
-			</p>
+			{description && (
+				<p>{description}</p>
+			)}
 		</div>
 		{!!headings.length && <TOC headings={headings} />}
 	</aside>


### PR DESCRIPTION
- Description field is no longer needed in Notion\n- Layouts now render description only if present\n- README updated to reflect requirement changes